### PR TITLE
Initialize argc and argv and add UFUNC table symbol

### DIFF
--- a/include/yt_combo.h
+++ b/include/yt_combo.h
@@ -21,6 +21,7 @@
 #define NO_IMPORT_ARRAY
 #endif
 #define PY_ARRAY_UNIQUE_SYMBOL LIBYT_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL LIBYT_UFUNC_API
 
 // to get rid of the warning messages about using deprecated NumPy API
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/src/init_python.cpp
+++ b/src/init_python.cpp
@@ -38,14 +38,12 @@ int init_python( int argc, char *argv[] )
 
 // Q: What can argc, argv be used for?
 // A: Probably can encode some settings, but since we aren't use them, comment them out.
-   // wchar_t **wchar_t_argv = (wchar_t **) malloc(argc * sizeof(wchar_t *));
-   // wchar_t wchar_temp[1000];
-   // for (int i = 0; i < argc; i = i+1) {
-	  // printf("argv[%d] = %s\n", i, argv[i]);
-   //    mbtowc(wchar_temp, argv[i], 1000);
-   //    wchar_t_argv[i] = wchar_temp;
-   // }
-   // PySys_SetArgv( argc, wchar_t_argv );
+   wchar_t **wchar_t_argv = (wchar_t **) malloc(argc * sizeof(wchar_t *));
+   for (int i = 0; i < argc; i = i+1) {
+	  printf("argv[%d] = %s\n", i, argv[i]);
+      wchar_t_argv[i] = Py_DecodeLocale(argv[0], NULL);;
+   }
+   PySys_SetArgv( argc, wchar_t_argv );
 
 
 // import numpy

--- a/src/init_python.cpp
+++ b/src/init_python.cpp
@@ -36,14 +36,14 @@ int init_python( int argc, char *argv[] )
    else {
       YT_ABORT(  "Initializing Python interpreter ... failed!\n" ); }
 
-// Q: What can argc, argv be used for?
-// A: Probably can encode some settings, but since we aren't use them, comment them out.
-   wchar_t **wchar_t_argv = (wchar_t **) malloc(argc * sizeof(wchar_t *));
-   for (int i = 0; i < argc; i = i+1) {
-	  printf("argv[%d] = %s\n", i, argv[i]);
-      wchar_t_argv[i] = Py_DecodeLocale(argv[0], NULL);;
-   }
-   PySys_SetArgv( argc, wchar_t_argv );
+//   Probably can encode some settings, but since we aren't use them, comment them out.
+//   This needs extra care and consider different Python versions.
+//   wchar_t **wchar_t_argv = (wchar_t **) malloc(argc * sizeof(wchar_t *));
+//   for (int i = 0; i < argc; i = i+1) {
+//	    printf("argv[%d] = %s\n", i, argv[i]);
+//      wchar_t_argv[i] = Py_DecodeLocale(argv[0], NULL);;
+//   }
+//   PySys_SetArgv( argc, wchar_t_argv );
 
 
 // import numpy


### PR DESCRIPTION
This adds initialization of the `argc` and `argv` variables, which in some cases is required for initializing the `sys` module.  It also adds another table header symbol to avoid conflicts, this time for UFUNC.